### PR TITLE
binary search instead of linear search and new event object specification

### DIFF
--- a/lib/PseudoAudioParam.js
+++ b/lib/PseudoAudioParam.js
@@ -7,6 +7,55 @@ var getExponentialRampToValueAtTime = expr.getExponentialRampToValueAtTime;
 var getTargetValueAtTime = expr.getTargetValueAtTime;
 var getValueCurveAtTime = expr.getValueCurveAtTime;
 
+/***************************************************************/
+/******************* BINARY SEARCH FUNCTIONS *******************/
+/***************************************************************/
+function find_index(values, target, compareFn) {
+  if (values.length == 0 || compareFn(target, values[0]) < 0) { 
+    return [undefined, 0]; 
+  }
+  if (compareFn(target, values[values.length-1]) > 0 ) {
+    return [values.length-1, undefined];
+  }
+  return modified_binary_search(values, 0, values.length - 1, target, compareFn);
+}
+
+function modified_binary_search(values, start, end, target, compareFn) {
+  // if the target is bigger than the last of the provided values.
+  if (start > end) { return [end, undefined]; } 
+
+  var middle = Math.floor((start + end) / 2);
+  var middleValue = values[middle];
+
+  if (compareFn(middleValue, target) < 0 && values[middle+1] && compareFn(values[middle+1], target) > 0) {
+    // if the target is in between the two halfs.
+    // console.log('middle: ' + middle);
+    return [middle, middle+1];
+  }
+  else if (compareFn(middleValue, target) > 0)
+    return modified_binary_search(values, start, middle-1, target, compareFn); 
+  else if (compareFn(middleValue, target) < 0)
+    return modified_binary_search(values, middle+1, end, target, compareFn); 
+  else 
+    return [middle]; //found!
+}
+/***************************************************************/
+/***************************************************************/
+/***************************************************************/
+
+/*
+  Event specification:
+    <> type  (String, required): one of ["setValueCurveAtTime","setTargetAtTime","exponentialRampToValueAtTime","linearRampToValueAtTime","setValueAtTime"].
+    <> time  (Number, required)
+    <> value (Number): not required if type === "setValueCurveAtTime"
+    <> timeConstant (Number): required if type === "setTargetAtTime"
+    <> duration (Number): required if type === "setValueCurveAtTime"
+    <> curve (Array): required if type === "setValueCurveAtTime"
+    <> args (Array): TODO
+ */
+
+
+
 function PseudoAudioParam(defaultValue) {
   this._defaultValue = defaultValue || 0;
   this.events = [];
@@ -16,6 +65,7 @@ PseudoAudioParam.prototype.setValueAtTime = function(value, time) {
   this._insertEvent({
     type: "setValueAtTime",
     time: time,
+    value: value, 
     args: [ value, time ]
   });
   return this;
@@ -23,8 +73,9 @@ PseudoAudioParam.prototype.setValueAtTime = function(value, time) {
 
 PseudoAudioParam.prototype.linearRampToValueAtTime = function(value, time) {
   this._insertEvent({
-    type: "linearRampToValueAtTime",
-    time: time,
+    type: "linearRampToValueAtTime", 
+    time: time, 
+    value: value, 
     args: [ value, time ]
   });
   return this;
@@ -32,8 +83,9 @@ PseudoAudioParam.prototype.linearRampToValueAtTime = function(value, time) {
 
 PseudoAudioParam.prototype.exponentialRampToValueAtTime = function(value, time) {
   this._insertEvent({
-    type: "exponentialRampToValueAtTime",
-    time: time,
+    type: "exponentialRampToValueAtTime", 
+    time: time, 
+    value: value, 
     args: [ value, time ]
   });
   return this;
@@ -41,8 +93,10 @@ PseudoAudioParam.prototype.exponentialRampToValueAtTime = function(value, time) 
 
 PseudoAudioParam.prototype.setTargetAtTime = function(value, time, timeConstant) {
   this._insertEvent({
-    type: "setTargetAtTime",
-    time: time,
+    type: "setTargetAtTime", 
+    time: time, 
+    value: value, 
+    timeConstant: timeConstant, 
     args: [ value, time, timeConstant ]
   });
   return this;
@@ -52,6 +106,8 @@ PseudoAudioParam.prototype.setValueCurveAtTime = function(curve, time, duration)
   this._insertEvent({
     type: "setValueCurveAtTime",
     time: time,
+    curve: curve, 
+    duration: duration, 
     args: [ curve, time, duration ]
   });
   return this;
@@ -70,7 +126,26 @@ PseudoAudioParam.prototype.getValueAtTime = function(time) {
   var i, imax;
   var e0, e1, t0;
 
-  for (i = 0, imax = events.length; i < imax; i++) {
+  // TODO: initialize 'target' and 'compareFn' in the constructor to avoid the garbage collector.
+  // console.log('----------------');
+  var idx = find_index(events, { time: time }, function(a, b) { return a.time - b.time; });
+  var pIdx = idx[0];
+  var nIdx = idx[1];
+  // console.log('requested time: ' + time);
+  // console.log(events);
+  // console.log(idx);
+  // console.log('----------------');
+  // console.log('');
+  // console.log('');
+
+  if (idx.length === 1 || pIdx !== undefined) {
+    i = pIdx;
+  } else if (nIdx !== undefined) {
+    i = nIdx;
+  }
+
+
+  for (i = Math.max(0, i-1), imax = events.length; i < imax; i++) {
     e0 = events[i];
     e1 = events[i + 1];
     t0 = Math.min(time, e1 ? e1.time : time);
@@ -80,26 +155,26 @@ PseudoAudioParam.prototype.getValueAtTime = function(time) {
     }
 
     switch (e0.type) {
-    case "setValueAtTime":
-    case "linearRampToValueAtTime":
-    case "exponentialRampToValueAtTime":
-      value = e0.args[0];
-      break;
-    case "setTargetAtTime":
-      value = getTargetValueAtTime(t0, value, e0.args[0], e0.args[1], e0.args[2]);
-      break;
-    case "setValueCurveAtTime":
-      value = getValueCurveAtTime(t0, e0.args[0], e0.args[1], e0.args[2]);
-      break;
+      case "setValueAtTime":
+      case "linearRampToValueAtTime":
+      case "exponentialRampToValueAtTime":
+        value = e0.value;
+        break;
+      case "setTargetAtTime":
+        value = getTargetValueAtTime(t0, value, e0.value, e0.time, e0.timeConstant);
+        break;
+      case "setValueCurveAtTime":
+        value = getValueCurveAtTime(t0, e0.curve, e0.time, e0.duration);
+        break;
     }
     if (e1) {
       switch (e1.type) {
-      case "linearRampToValueAtTime":
-        value = getLinearRampToValueAtTime(t0, value, e1.args[0], e0.time, e1.args[1]);
-        break;
-      case "exponentialRampToValueAtTime":
-        value = getExponentialRampToValueAtTime(t0, value, e1.args[0], e0.time, e1.args[1]);
-        break;
+        case "linearRampToValueAtTime":
+          value = getLinearRampToValueAtTime(t0, value, e1.value, e0.time, e1.time);
+          break;
+        case "exponentialRampToValueAtTime":
+          value = getExponentialRampToValueAtTime(t0, value, e1.value, e0.time, e1.time);
+          break;
       }
     }
   }
@@ -118,21 +193,15 @@ PseudoAudioParam.prototype._insertEvent = function(eventItem) {
   var time = eventItem.time;
   var events = this.events;
   var replace = 0;
-  var i, imax;
+  var i;
 
-  if (events.length === 0 || events[events.length - 1].time < time) {
-    events.push(eventItem);
+  var idx = find_index(events, eventItem, function(a, b) { return a.time - b.time; });
+
+  if (idx.length === 1) {
+    events[idx[0]] = eventItem;
   } else {
-    for (i = 0, imax = events.length; i < imax; i++) {
-      if (events[i].time === time && events[i].type === eventItem.type) {
-        replace = 1;
-        break;
-      }
-      if (time < events[i].time) {
-        break;
-      }
-    }
-    events.splice(i, replace, eventItem);
+    events.push(eventItem);
+    events.sort(function(a,b) { return a.time - b.time; });
   }
 };
 

--- a/test/PseudoAudioParam.js
+++ b/test/PseudoAudioParam.js
@@ -27,6 +27,7 @@ describe("PseudoAudioParam", () => {
       assert(param instanceof PseudoAudioParam);
     });
   });
+
   describe("#setValueAtTime(value: number, time: number): self", () => {
     it("inserts 'setValueAtTime' event into the schedule at time", () => {
       let param = new PseudoAudioParam()
@@ -34,12 +35,13 @@ describe("PseudoAudioParam", () => {
         .setValueAtTime(2, 20)
         .setValueAtTime(1, 10)
         .setValueAtTime(3, 20);
+      // console.log(param.events);
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 0, 0 ] },
-        { type: "setValueAtTime", time: 10, args: [ 1, 10 ] },
-        { type: "setValueAtTime", time: 20, args: [ 3, 20 ] }
+        { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
+        { type: "setValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
+        { type: "setValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
       ]);
       assert(param.getValueAtTime(0) === 0);
       assert(param.getValueAtTime(5) === 0);
@@ -49,6 +51,7 @@ describe("PseudoAudioParam", () => {
       assert(param.getValueAtTime(25) === 3);
     });
   });
+
   describe("#linearRampToValueAtTime(value: number, time: number): self", () => {
     it("inserts 'linearRampToValueAtTime' event into the schedule at time", () => {
       let param = new PseudoAudioParam()
@@ -59,9 +62,9 @@ describe("PseudoAudioParam", () => {
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 0, 0 ] },
-        { type: "linearRampToValueAtTime", time: 10, args: [ 1, 10 ] },
-        { type: "linearRampToValueAtTime", time: 20, args: [ 3, 20 ] }
+        { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
+        { type: "linearRampToValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
+        { type: "linearRampToValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
       ]);
       assert(param.getValueAtTime(0) === 0);
       assert(param.getValueAtTime(5) === 0.5);
@@ -71,6 +74,7 @@ describe("PseudoAudioParam", () => {
       assert(param.getValueAtTime(25) === 3);
     });
   });
+
   describe("#exponentialRampToValueAtTime(value: number, time: number): self", () => {
     it("inserts 'exponentialRampToValueAtTime' event into the schedule at time", () => {
       let param = new PseudoAudioParam()
@@ -81,9 +85,9 @@ describe("PseudoAudioParam", () => {
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 1e-4, 0 ] },
-        { type: "exponentialRampToValueAtTime", time: 10, args: [ 1, 10 ] },
-        { type: "exponentialRampToValueAtTime", time: 20, args: [ 3, 20 ] }
+        { type: "setValueAtTime", time: 0, value: 1e-4, args: [ 1e-4, 0 ] },
+        { type: "exponentialRampToValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
+        { type: "exponentialRampToValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
       ]);
       assert(param.getValueAtTime(0) === 1e-4);
       assert(closeTo(param.getValueAtTime(5), 0.01, 1e-4));
@@ -93,6 +97,7 @@ describe("PseudoAudioParam", () => {
       assert(param.getValueAtTime(25) === 3);
     });
   });
+
   describe("#setTargetAtTime(value: number, time: number, timeConstant: number): self", () => {
     it("inserts 'setTargetAtTime' event into the schedule at time", () => {
       let param = new PseudoAudioParam()
@@ -103,10 +108,11 @@ describe("PseudoAudioParam", () => {
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 0, 0 ] },
-        { type: "setTargetAtTime", time: 10, args: [ 1, 10, 2 ] },
-        { type: "setTargetAtTime", time: 20, args: [ 3, 20, 2 ] }
+        { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
+        { type: "setTargetAtTime", time: 10, value: 1, timeConstant: 2, args: [ 1, 10, 2 ] },
+        { type: "setTargetAtTime", time: 20, value: 3, timeConstant: 2, args: [ 3, 20, 2 ] }
       ]);
+
       assert(param.getValueAtTime(0) === 0);
       assert(param.getValueAtTime(5) === 0);
       assert(param.getValueAtTime(10) === 0);
@@ -115,6 +121,7 @@ describe("PseudoAudioParam", () => {
       assert(closeTo(param.getValueAtTime(25), 2.835276, 1e-4));
     });
   });
+  
   describe("#setValueCurveAtTime(curve: Float32Array, time: number, duration: number): self", () => {
     it("inserts 'setValueCurveAtTime' event into the schedule at time", () => {
       let curve = (() => {
@@ -134,9 +141,9 @@ describe("PseudoAudioParam", () => {
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 0, 0 ] },
-        { type: "setValueCurveAtTime", time: 10, args: [ curve, 10, 10 ] },
-        { type: "setValueCurveAtTime", time: 20, args: [ curve, 20, 20 ] }
+        { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
+        { type: "setValueCurveAtTime", time: 10, curve: curve, duration: 10, args: [ curve, 10, 10 ] },
+        { type: "setValueCurveAtTime", time: 20, curve: curve, duration: 20, args: [ curve, 20, 20 ] }
       ]);
       assert(param.getValueAtTime(0) === 0);
       assert(param.getValueAtTime(5) === 0);
@@ -146,6 +153,7 @@ describe("PseudoAudioParam", () => {
       assert(closeTo(param.getValueAtTime(25), 0.702715, 1e-4));
     });
   });
+  
   describe("#cancelScheduledValues(time: number): self", () => {
     it("removes events from the schedule after time", () => {
       let param = new PseudoAudioParam()
@@ -155,15 +163,17 @@ describe("PseudoAudioParam", () => {
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
-        { type: "setValueAtTime", time: 0, args: [ 0, 0 ] }
+        { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] }
       ]);
     });
   });
+  
   describe("#getValueAtTime(time: number): number", () => {
     it("returns value at time", () => {
 
     });
   });
+
   describe("#applyTo(audioParam: AudioParam): self", () => {
     it("call scheduled api methods to the audioParam", () => {
       let audioParam = createAudioParamMock();
@@ -177,4 +187,5 @@ describe("PseudoAudioParam", () => {
       assert.deepEqual(audioParam.setValueAtTime.args[1], [ 1, 10 ]);
     });
   });
+
 });


### PR DESCRIPTION
1. 'getValueAtTime' uses binary search, as well as '_insertEvent'. 
2. New specification for the event object. 
3. Changed the unit tests in order to allow the new event object specification. 
