### PR TITLE
(custom) AVL Tree instead of Array

### DIFF
--- a/lib/PseudoAudioParam.js
+++ b/lib/PseudoAudioParam.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var expr = require("./expr");
+var AVLTree = require("./avl-tree");
 
 var getLinearRampToValueAtTime = expr.getLinearRampToValueAtTime;
 var getExponentialRampToValueAtTime = expr.getExponentialRampToValueAtTime;
@@ -56,7 +57,7 @@ function modified_binary_search(values, start, end, target, compareFn) {
 
 
 function PseudoAudioParam(defaultValue) {
-  this.events = [];
+  this.events = new AVLTree(function(a, b) { return a.time - b.time; }, function(a, b) { return a.time === b.time; });
 
   this.default = {
     time: 0, 
@@ -118,9 +119,16 @@ PseudoAudioParam.prototype.setValueCurveAtTime = function(curve, time, duration)
 };
 
 PseudoAudioParam.prototype.cancelScheduledValues = function(time) {
-  this.events = this.events.filter(function(eventItem) {
-    return eventItem.time < time;
-  });
+  var node = this.events.search_closest({ time: time });
+
+  while (node) {
+    var eventItem = node.val;
+    if (eventItem.time >= time) {
+      this.events.remove(eventItem);
+    }
+    node = node.next;
+  }
+
   return this;
 };
 
@@ -130,26 +138,36 @@ PseudoAudioParam.prototype.getValueAtTime = function(time) {
   var i, imax;
   var e0, e1, t0;
 
-  // TODO: initialize 'target' and 'compareFn' in the constructor to avoid the garbage collector.
-  var idx = find_index(events, { time: time }, function(a, b) { return a.time - b.time; });
-  var pIdx = idx[0];
-  var nIdx = idx[1];
+  var obj = { time: time };
+  var node = this.events.search_closest({ time: time });
 
-  if (idx.length === 1 || pIdx !== undefined) {
-    i = pIdx;
-  } else if (nIdx !== undefined) {
-    i = nIdx;
+  // Se fôr o nó exacto, não faz nada.
+  // Se houver um nós com chave menor, usa esse nó.
+  //  Senão Se existir um nó seguinte, usa esse nó.
+
+  if (!this.events.equality(obj, node.val)) {
+    var prevNode, nextNode;
+    if (this.events.comparison(obj, node.val) < 0) {
+      prevNode = node.previous;
+      nextNode = node;
+    } else {
+      prevNode = node;
+      nextNode = node.next;
+    }
+    if (prevNode) {
+      node = prevNode;
+    } else if (nextNode) {
+      node = nextNode;
+    }
   }
 
-  for (i = i-1, imax = events.length; i < imax; i++) {
-    if (i === -1) {
-      e0 = this.default;
-      e1 = events[0];
-    } else {
-      e0 = events[i];
-      e1 = events[i + 1];
-    }
-    
+  node = (node.previous)? node.previous : node;
+
+  while (node) {
+
+    e0 = node.val;
+    e1 = (node.next)? node.next.val : undefined;
+
     t0 = Math.min(time, e1 ? e1.time : time);
 
     if (time < e0.time) {
@@ -179,31 +197,39 @@ PseudoAudioParam.prototype.getValueAtTime = function(time) {
           break;
       }
     }
+
+    node = node.next;
   }
 
   return value;
 };
 
-PseudoAudioParam.prototype.applyTo = function(audioParam) {
-  this.events.forEach(function(eventItem) {
+PseudoAudioParam.prototype.applyTo = function(audioParam, reset) {
+  if (reset) {
+    audioParam.cancelScheduledValues(0);
+  }
+  
+  var node = this.events.minNode;
+
+  while (node) {
+    var eventItem = node.val;
     audioParam[eventItem.type].apply(audioParam, eventItem.args);
-  });
+    node = node.next;
+  }
+
   return this;
 };
 
+PseudoAudioParam.prototype._removeEvent = function(time) {
+  this.events.remove({ time: time });
+};
+
 PseudoAudioParam.prototype._insertEvent = function(eventItem) {
-  var time = eventItem.time;
-  var events = this.events;
-  var replace = 0;
-  var i;
-
-  var idx = find_index(events, eventItem, function(a, b) { return a.time - b.time; });
-
-  if (idx.length === 1) {
-    events[idx[0]] = eventItem;
+  var node = this.events.search(eventItem);
+  if (node === null) {
+    this.events.add(eventItem);
   } else {
-    events.push(eventItem);
-    events.sort(function(a,b) { return a.time - b.time; });
+    node.val = eventItem;
   }
 };
 

--- a/lib/PseudoAudioParam.js
+++ b/lib/PseudoAudioParam.js
@@ -8,41 +8,6 @@ var getExponentialRampToValueAtTime = expr.getExponentialRampToValueAtTime;
 var getTargetValueAtTime = expr.getTargetValueAtTime;
 var getValueCurveAtTime = expr.getValueCurveAtTime;
 
-/***************************************************************/
-/******************* BINARY SEARCH FUNCTIONS *******************/
-/***************************************************************/
-function find_index(values, target, compareFn) {
-  if (values.length === 0 || compareFn(target, values[0]) < 0) { 
-    return [undefined, 0]; 
-  }
-  if (compareFn(target, values[values.length-1]) > 0 ) {
-    return [values.length-1, undefined];
-  }
-  return modified_binary_search(values, 0, values.length - 1, target, compareFn);
-}
-
-function modified_binary_search(values, start, end, target, compareFn) {
-  // if the target is bigger than the last of the provided values.
-  if (start > end) { return [end, undefined]; } 
-
-  var middle = Math.floor((start + end) / 2);
-  var middleValue = values[middle];
-
-  if (compareFn(middleValue, target) < 0 && values[middle+1] && compareFn(values[middle+1], target) > 0) {
-    // if the target is in between the two halfs.
-    return [middle, middle+1];
-  }
-  else if (compareFn(middleValue, target) > 0)
-    return modified_binary_search(values, start, middle-1, target, compareFn); 
-  else if (compareFn(middleValue, target) < 0)
-    return modified_binary_search(values, middle+1, end, target, compareFn); 
-  else 
-    return [middle]; //found!
-}
-/***************************************************************/
-/***************************************************************/
-/***************************************************************/
-
 /*
   Event specification:
     <> type  (String, required): one of ["setValueCurveAtTime","setTargetAtTime","exponentialRampToValueAtTime","linearRampToValueAtTime","setValueAtTime"].
@@ -208,7 +173,7 @@ PseudoAudioParam.prototype.applyTo = function(audioParam, reset) {
   if (reset) {
     audioParam.cancelScheduledValues(0);
   }
-  
+
   var node = this.events.minNode;
 
   while (node) {

--- a/lib/PseudoAudioParam.js
+++ b/lib/PseudoAudioParam.js
@@ -11,7 +11,7 @@ var getValueCurveAtTime = expr.getValueCurveAtTime;
 /******************* BINARY SEARCH FUNCTIONS *******************/
 /***************************************************************/
 function find_index(values, target, compareFn) {
-  if (values.length == 0 || compareFn(target, values[0]) < 0) { 
+  if (values.length === 0 || compareFn(target, values[0]) < 0) { 
     return [undefined, 0]; 
   }
   if (compareFn(target, values[values.length-1]) > 0 ) {
@@ -29,7 +29,6 @@ function modified_binary_search(values, start, end, target, compareFn) {
 
   if (compareFn(middleValue, target) < 0 && values[middle+1] && compareFn(values[middle+1], target) > 0) {
     // if the target is in between the two halfs.
-    // console.log('middle: ' + middle);
     return [middle, middle+1];
   }
   else if (compareFn(middleValue, target) > 0)
@@ -57,8 +56,13 @@ function modified_binary_search(values, start, end, target, compareFn) {
 
 
 function PseudoAudioParam(defaultValue) {
-  this._defaultValue = defaultValue || 0;
   this.events = [];
+
+  this.default = {
+    time: 0, 
+    value: defaultValue || 0, 
+    type: "setValueAtTime"
+  };
 }
 
 PseudoAudioParam.prototype.setValueAtTime = function(value, time) {
@@ -122,21 +126,14 @@ PseudoAudioParam.prototype.cancelScheduledValues = function(time) {
 
 PseudoAudioParam.prototype.getValueAtTime = function(time) {
   var events = this.events;
-  var value = this._defaultValue;
+  var value = this.default.value;
   var i, imax;
   var e0, e1, t0;
 
   // TODO: initialize 'target' and 'compareFn' in the constructor to avoid the garbage collector.
-  // console.log('----------------');
   var idx = find_index(events, { time: time }, function(a, b) { return a.time - b.time; });
   var pIdx = idx[0];
   var nIdx = idx[1];
-  // console.log('requested time: ' + time);
-  // console.log(events);
-  // console.log(idx);
-  // console.log('----------------');
-  // console.log('');
-  // console.log('');
 
   if (idx.length === 1 || pIdx !== undefined) {
     i = pIdx;
@@ -144,10 +141,15 @@ PseudoAudioParam.prototype.getValueAtTime = function(time) {
     i = nIdx;
   }
 
-
-  for (i = Math.max(0, i-1), imax = events.length; i < imax; i++) {
-    e0 = events[i];
-    e1 = events[i + 1];
+  for (i = i-1, imax = events.length; i < imax; i++) {
+    if (i === -1) {
+      e0 = this.default;
+      e1 = events[0];
+    } else {
+      e0 = events[i];
+      e1 = events[i + 1];
+    }
+    
     t0 = Math.min(time, e1 ? e1.time : time);
 
     if (time < e0.time) {

--- a/lib/avl-tree.js
+++ b/lib/avl-tree.js
@@ -1,0 +1,529 @@
+// The file contatins the AVLTree class written by Simon Karman
+//
+// The AVLTree is a self-balancing binary search tree. In an AVL tree, 
+//  the heights of the two child subtrees of any node differ by at most 
+//  one; if at any time they differ by more than one, rebalancing is 
+//  done to restore this property. Lookup, insertion, and deletion all 
+//  take O(log n) time in both the average and worst cases, where n is 
+//  the number of nodes in the tree prior to the operation. Insertions 
+//  and deletions may require the tree to be rebalanced by one or more 
+//  tree rotations.
+//  (https://en.wikipedia.org/wiki/AVL_tree)
+//
+// You can use or modify this file to your own needs and are allowed to
+//  use it for your own projets. However if you do so, please give me
+//  (Simon Karman) credit.
+//
+// Last Modified - 16 juni 2015
+// (http://www.simonkarman.nl)
+ 
+// The constructor for the AVLTree
+//
+// The AVLTree has a member this.root which holds the root node of the 
+//  tree and in this.count it keeps track of the total number of nodes 
+//  that are currently in the tree.
+//
+// The AVLTree has the following public functions: clear, min, max, 
+//  traverse, add, search, remove and removeNode. The description and
+//  usage of all these functions are given below.
+//
+// @param _comparison (optional) A comparison function in the form of 
+//    [number func(x, y)] that returns whether a val x is smaller, 
+//    equal or greater than a value y. By default this function works 
+//    only for numbers and strings.
+// @param _equality (optional) An equality function in the form of
+//    [boolean func(x, y)] that returns whether a val x is equal to
+//    val y. By default this function works only for numbers and 
+//    strings.
+// @return Returns the AVLTree that was initialized
+var AVLTree = function (_comparison, _equality) {
+    this.root = null;
+    this.count = 0;
+    this.minNode = null;
+    this.maxNode = null;
+
+    this.comparison = _comparison ? _comparison : function (val1, val2) {
+        return val1 - val2;
+    };
+    this.equality = _equality ? _equality : function (val1, val2) {
+        return val1 === val2;
+    };
+}
+
+// Node is the internal class of the AVLTree that is used for
+//  storing the values and maintaining the structure of the
+//  AVLTree.
+//
+// The Node class has the following properties:
+//  val (?)         The value of the node.
+//  parent (Node)   The parent of the node.
+//  balanceFactor   The longest chain of nodes under its left child
+//   (number)       minus the longest chain of nodes under its right
+//                  child.
+// left (Node)      The left child of the node.
+// right (Node)     The right child of the node.
+//
+// @param val The value of the node.
+// @returns The new Node that is created.
+var Node = function(val) {
+    this.val = val;
+    this.parent = null;
+    this.balanceFactor = 0;
+ 
+    this.left = null;
+    this.right = null;
+
+    this.previous = null;
+    this.next = null;
+ 
+    this.isRoot = function() {
+        return (this.parent == null);
+    }
+ 
+    this.isLeaf = function() {
+        return (this.left == null) && (this.right == null);
+    };
+ 
+    this.isLeftChild = function() {
+        return this.parent.left == this;
+    };
+}
+
+// Clears all the nodes of the AVLTree.
+AVLTree.prototype.clear = function() {
+    this.root = null;
+    this.count = 0;
+}
+
+// Returns the minimal value currently present in the AVLTree.
+// @returns The minimal value.
+AVLTree.prototype.min = function () {
+    if (this.root == null)
+        return undefined;
+
+    var maxNode = this.root;
+    while (maxNode.left != null) {
+        maxNode = maxNode.left;
+    }
+
+    return maxNode.val;
+}
+
+// Returns the maximal value currently present in the AVLTree.
+// @returns The maximal value.
+AVLTree.prototype.max = function () {
+    if (this.root == null)
+        return undefined;
+
+    var maxNode = this.root;
+    while (maxNode.right != null) {
+        maxNode = maxNode.right;
+    }
+
+    return maxNode.val;
+}
+
+// Traverse the AVLTree in ascending sorted order.
+// @returns An array of the values in the AVLTree in ascending 
+//     sorted order.
+AVLTree.prototype.traverse = function () {
+    var arr = [],
+        inOrder = function (node) {
+            if (node == null) {
+                return;
+            }
+            inOrder(node.left);
+            // arr.push(node.val);
+            arr.push(node);
+            inOrder(node.right);
+        };
+    inOrder(this.root);
+    return arr;
+}
+
+// Adds a new value to the AVLTree and balances the AVLTree if
+//  neccessary.
+// @param val The value to be added.
+// @returns The new node that was added to the AVLTree.
+AVLTree.prototype.add = function(val) {
+    var newNode = new Node(val);
+    this.count += 1;
+ 
+    if (this.root == null) {
+        this.root = newNode;
+        this.minNode = newNode;
+        this.maxNode = newNode;
+        return newNode;
+    }
+ 
+    var currentNode = this.root;
+    while (true) {
+        if (this.comparison(val, currentNode.val) < 0) {
+            if (currentNode.left) {
+                // if (Math.abs(this.comparison(val, currentNode.val)) < Math.abs(this.comparison(currentNode.previous.val, currentNode.val))) {
+                //     console.log("caminhou para a esquerda e o 'val' é mais perto do que o 'currentNode.previous.val'.");
+                //     console.log({ val: val, previousVal: currentNode.previous.val, currVal: currentNode.val });
+                // }
+
+                var difVal = Math.abs(this.comparison(val, currentNode.val));
+                var difPreviousVal = Math.abs(this.comparison(currentNode.previous.val, currentNode.val));
+                // console.log('caminhou para a esquerda');
+                // console.log({ val: val, previousVal: currentNode.previous.val, currVal: currentNode.val });
+                // console.log({ difVal: difVal, difPreviousVal: difPreviousVal });
+                if (difVal < difPreviousVal) {
+                    // console.log('o novo nó passará a ser o currentNode.previous');
+                    currentNode.previous = newNode;
+                    newNode.next = currentNode;
+                }
+
+                currentNode = currentNode.left;
+            } else {
+                currentNode.left = newNode;
+                currentNode.previous = newNode;
+                newNode.next = currentNode;
+                break;
+            }
+        } else {
+            if (currentNode.right) {
+                // if (Math.abs(this.comparison(val, currentNode.val)) < Math.abs(this.comparison(currentNode.next.val, currentNode.val))) {
+                //     console.log("caminhou para a direita e o 'val' é mais perto do que o 'currentNode.next.val'.");
+                //     console.log({ val: val, nextVal: currentNode.next.val, currVal: currentNode.val });
+                // }
+
+                var difVal = Math.abs(this.comparison(val, currentNode.val));
+                var difNextVal = Math.abs(this.comparison(currentNode.next.val, currentNode.val));
+                // console.log('caminhou para a direita');
+                // console.log({ val: val, nextVal: currentNode.next.val, currVal: currentNode.val });
+                // console.log({ difVal: difVal, difNextVal: difNextVal });
+                if (difVal < difNextVal) {
+                    // console.log('o novo nó passará a ser o currentNode.next');
+                    currentNode.next = newNode;
+                    newNode.previous = currentNode;
+                }
+
+                currentNode = currentNode.right;
+            } else {
+                currentNode.right = newNode;
+                currentNode.next = newNode;
+                newNode.previous = currentNode;
+                break;
+            }   
+        }
+    }
+    newNode.parent = currentNode;
+ 
+    currentNode = newNode;
+    while (currentNode.parent) {
+        var parent = currentNode.parent,
+            prevBalanceFactor = parent.balanceFactor;
+     
+        if (currentNode.isLeftChild()) {
+            parent.balanceFactor += 1;
+        } else {
+            parent.balanceFactor -= 1;
+        }
+     
+        if (Math.abs(parent.balanceFactor) < Math.abs(prevBalanceFactor)) {
+            break;
+        }
+     
+        if (parent.balanceFactor < -1 || parent.balanceFactor > 1) {
+            this._rebalance(parent);
+            break;
+        }
+        currentNode = parent;
+    }
+
+    if (this.minNode === null || this.comparison(newNode.val, this.minNode.val) < 0) 
+        this.minNode = newNode;
+    if (this.maxNode === null || this.comparison(newNode.val, this.maxNode.val) > 0) 
+        this.maxNode = newNode;
+ 
+    return newNode;
+}
+
+// Searches for a certain value in the AVLTree and returns the
+//  corresponding node.
+// @param val The value to search for.
+// @returns The node that contains the value, or null when it is
+//     not in the AVLTree.
+AVLTree.prototype.search = function (val) {
+    var currentNode = this.root;
+    while (currentNode) {
+        if (this.equality(val, currentNode.val)) {
+            return currentNode;
+        }
+
+        if (this.comparison(val, currentNode.val) < 0) {
+            currentNode = currentNode.left;
+        } else {
+            currentNode = currentNode.right;
+        }
+    }
+    return null;
+}
+
+AVLTree.prototype.search_closest = function(val) {
+    var currentNode = this.root;
+    var closestNode = this.root;
+    var minDist = Math.abs(this.comparison(val, closestNode.val));
+    while (currentNode) {
+        if (this.equality(val, currentNode.val)) {
+            return currentNode;
+        }
+
+        var dist = this.comparison(val, currentNode.val);
+
+        if ( minDist > Math.abs(dist) ) {
+            minDist = Math.abs(dist);
+            closestNode = currentNode;
+        }
+
+        if (dist < 0) {
+            currentNode = currentNode.left;
+        } else {
+            currentNode = currentNode.right;
+        }
+    }
+    return closestNode;
+}
+
+// Removes a val from the AVLTree and rebalances it when neccesarry.
+// @param val The value to remove.
+// @returns Whether the value was removed. The value can not be removed
+//    when it is not found in the tree.
+AVLTree.prototype.remove = function (val) {
+    var foundNode = this.search(val);
+    if (foundNode) {
+        this.removeNode(foundNode);
+        if (foundNode.previous !== null) 
+            foundNode.previous.next = foundNode.next;
+        if (foundNode.next !== null) 
+            foundNode.next.previous = foundNode.previous;
+    }
+    return foundNode;
+}
+
+// Removes a node from the AVLTree and rebalances it when neccessary.
+// @param node The node to remove.
+AVLTree.prototype.removeNode = function (node) {
+    var currentNode = node;
+    this.count -= 1;
+    if ((currentNode.left == null) || (currentNode.right == null)) {
+        if (currentNode.isLeaf()) {
+            //0-Children
+            if (currentNode.isRoot()) {
+                this.root = null;
+            } else {
+                var fakeNode = {
+                    parent: currentNode.parent,
+                    isLeftChild: function () { return true; }
+                };
+                if (currentNode.isLeftChild()) {
+                    currentNode.parent.left = null;
+                } else {
+                    currentNode.parent.right = null;
+                    fakeNode.isLeftChild= function () { return false; };
+                }
+                currentNode = fakeNode;
+            }
+        } else {
+            //1-Child
+            var singleChild = currentNode.left ? currentNode.left : currentNode.right;
+            if (currentNode.isRoot()) {
+                this.root = singleChild;
+            } else {
+                if (currentNode.isLeftChild()) {
+                    currentNode.parent.left = singleChild;
+                } else {
+                    currentNode.parent.right = singleChild;
+                }
+            }
+            singleChild.parent = currentNode.parent;
+            currentNode = singleChild;
+        }
+    } else {
+        //2-Children
+        var minNode = currentNode.left;
+        while (minNode.right != null) {
+            minNode = minNode.right;
+        }
+     
+        if (currentNode.left == minNode) {
+            //Special 2-Children Case
+            if (currentNode.isRoot()) {
+                //Find parent of minNode and assign minNode
+                this.root = minNode;
+                //Set parent of minNode
+                minNode.parent = null;
+            } else {
+                //Find parent of minNode and assign minNode
+                if (currentNode.isLeftChild()) {
+                    currentNode.parent.left = minNode;
+                } else {
+                    currentNode.parent.right = minNode;
+                }
+                //Set parent of minNode
+                minNode.parent = currentNode.parent;
+            }
+            //Connect right of minNode
+            minNode.right = currentNode.right;
+            minNode.right.parent = minNode;
+
+            //Create fake node that comes from left of minNode to update balanceFactors
+            minNode.balanceFactor = currentNode.balanceFactor;
+            var fakeNode = {
+                parent: minNode,
+                isLeftChild: function() { return true; }
+            };
+            currentNode = fakeNode;
+        } else {
+            //Non-Special 2-Children Case
+
+            //Cache parent and left of the minNode
+            var minParent = minNode.parent;
+            var minLeft = minNode.left;
+
+            //Move minLeft to position of minNode
+            minParent.right = minLeft;
+            if (minLeft) {
+                minLeft.parent = minParent;
+            }
+
+            //Connect minNode to new parent
+            if (currentNode.isRoot()) {
+                //Find parent of minNode and assign minNode
+                this.root = minNode;
+                //Set parent of minNode
+                minNode.parent = null;
+            } else {
+                //Find parent of minNode and assign minNode
+                if (currentNode.isLeftChild()) {
+                    currentNode.parent.left = minNode;
+                } else {
+                    currentNode.parent.right = minNode;
+                }
+                //Set parent of minNode
+                minNode.parent = currentNode.parent;
+            }
+
+            //Connect minNode to children of currentNode
+            minNode.right = currentNode.right;
+            minNode.right.parent = minNode;
+            minNode.left = currentNode.left;
+            minNode.left.parent = minNode;
+            minNode.balanceFactor = currentNode.balanceFactor;
+
+            //Create fake node here:
+            var fakeNode = {
+                parent: minParent,
+                isLeftChild: function() { return false; }
+            };
+            currentNode = fakeNode;
+        }
+    }
+ 
+    //Rebalance the path back to the root
+    while (currentNode.parent) {
+        var parent = currentNode.parent,
+            prevBalanceFactor = parent.balanceFactor
+     
+        if (currentNode.isLeftChild()) {
+            parent.balanceFactor -= 1;
+        } else {
+            parent.balanceFactor += 1;
+        }
+     
+        if (Math.abs(parent.balanceFactor) > Math.abs(prevBalanceFactor)) {
+            //If moving further away from 0 balanceFactor
+         
+            if (parent.balanceFactor < -1 || parent.balanceFactor > 1) {
+                //If out of balance
+             
+                //Rebalance
+                this._rebalance(parent);
+             
+                //If balanceFactor is now 0, length has decreased on both sides, keep going with tracing back path
+                if (parent.parent.balanceFactor === 0) {                        
+                    currentNode = parent.parent;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        } else {
+            currentNode = parent;
+        }
+    }
+}
+
+// Private function used to rebalance the node when its balanceFactor is
+//  -2 or 2.
+AVLTree.prototype._rebalance = function (node) {
+    if (node.balanceFactor < 0) {
+        if (node.right.balanceFactor > 0) {
+            this._rotateRight(node.right);
+            this._rotateLeft(node);
+        } else {
+            this._rotateLeft(node);
+        }
+    } else if (node.balanceFactor > 0) {
+        if (node.left.balanceFactor < 0) {
+            this._rotateLeft(node.left);
+            this._rotateRight(node);
+        } else {
+            this._rotateRight(node);
+        }
+    }
+}
+
+// Private function used to preform a left rotation with a node as rotation
+//  root.
+AVLTree.prototype._rotateLeft = function (rotRoot) {
+    var newRoot = rotRoot.right;
+    rotRoot.right = newRoot.left;
+    if (newRoot.left != null) {
+        newRoot.left.parent = rotRoot;
+    }
+    newRoot.parent = rotRoot.parent;
+    if (rotRoot.parent == null) {
+        this.root = newRoot;
+    } else {
+        if (rotRoot.isLeftChild()) {
+            rotRoot.parent.left = newRoot;
+        } else {
+            rotRoot.parent.right = newRoot;
+        }
+    }
+    newRoot.left = rotRoot;
+    rotRoot.parent = newRoot;
+    rotRoot.balanceFactor = rotRoot.balanceFactor + 1 - Math.min(newRoot.balanceFactor, 0);
+    newRoot.balanceFactor = newRoot.balanceFactor + 1 + Math.max(rotRoot.balanceFactor, 0);
+}
+
+// Private function used to preform a right rotation with a node as rotation
+//  root.
+AVLTree.prototype._rotateRight = function (rotRoot) {
+    var newRoot = rotRoot.left;
+    rotRoot.left = newRoot.right;
+    if (newRoot.right != null) {
+        newRoot.right.parent = rotRoot;
+    }
+    newRoot.parent = rotRoot.parent;
+    if (rotRoot.parent == null) {
+        this.root = newRoot;
+    } else {
+        if (rotRoot.isLeftChild()) {
+            rotRoot.parent.left = newRoot;
+        } else {
+            rotRoot.parent.right = newRoot;
+        }
+    }
+    newRoot.right = rotRoot;
+    rotRoot.parent = newRoot;
+    rotRoot.balanceFactor = rotRoot.balanceFactor - 1 - Math.max(newRoot.balanceFactor, 0);
+    newRoot.balanceFactor = newRoot.balanceFactor - 1 + Math.min(rotRoot.balanceFactor, 0);
+}
+
+module.exports = AVLTree;

--- a/test/PseudoAudioParam.js
+++ b/test/PseudoAudioParam.js
@@ -35,7 +35,6 @@ describe("PseudoAudioParam", () => {
         .setValueAtTime(2, 20)
         .setValueAtTime(1, 10)
         .setValueAtTime(3, 20);
-      // console.log(param.events);
 
       assert(param instanceof PseudoAudioParam);
       assert.deepEqual(param.events, [
@@ -43,6 +42,7 @@ describe("PseudoAudioParam", () => {
         { type: "setValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
         { type: "setValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
       ]);
+
       assert(param.getValueAtTime(0) === 0);
       assert(param.getValueAtTime(5) === 0);
       assert(param.getValueAtTime(10) === 1);

--- a/test/PseudoAudioParam.js
+++ b/test/PseudoAudioParam.js
@@ -37,7 +37,8 @@ describe("PseudoAudioParam", () => {
         .setValueAtTime(3, 20);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
         { type: "setValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
         { type: "setValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
@@ -61,7 +62,8 @@ describe("PseudoAudioParam", () => {
         .linearRampToValueAtTime(3, 20);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
         { type: "linearRampToValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
         { type: "linearRampToValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
@@ -84,7 +86,8 @@ describe("PseudoAudioParam", () => {
         .exponentialRampToValueAtTime(3, 20);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 1e-4, args: [ 1e-4, 0 ] },
         { type: "exponentialRampToValueAtTime", time: 10, value: 1, args: [ 1, 10 ] },
         { type: "exponentialRampToValueAtTime", time: 20, value: 3, args: [ 3, 20 ] }
@@ -107,7 +110,8 @@ describe("PseudoAudioParam", () => {
         .setTargetAtTime(3, 20, 2);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
         { type: "setTargetAtTime", time: 10, value: 1, timeConstant: 2, args: [ 1, 10, 2 ] },
         { type: "setTargetAtTime", time: 20, value: 3, timeConstant: 2, args: [ 3, 20, 2 ] }
@@ -140,7 +144,8 @@ describe("PseudoAudioParam", () => {
         .setValueCurveAtTime(curve, 20, 20);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] },
         { type: "setValueCurveAtTime", time: 10, curve: curve, duration: 10, args: [ curve, 10, 10 ] },
         { type: "setValueCurveAtTime", time: 20, curve: curve, duration: 20, args: [ curve, 20, 20 ] }
@@ -162,7 +167,8 @@ describe("PseudoAudioParam", () => {
         .cancelScheduledValues(5);
 
       assert(param instanceof PseudoAudioParam);
-      assert.deepEqual(param.events, [
+      let events = param.events.traverse().map((node) => { return node.val; });
+      assert.deepEqual(events, [
         { type: "setValueAtTime", time: 0, value: 0, args: [ 0, 0 ] }
       ]);
     });


### PR DESCRIPTION
Now, insertions, removals and queries for values are performed in O(log N) time. Previously, due to the use of Array (and the splice method), the JS engine would need to create a new Array instance and write everything in the new instance. This means the removals and insertions would be O(N). Additionally, if you use an Array instance and you need to remove and insert event items during a script processor iteration, the garbage collector might "cause" audio dropouts (I noticed the impact of creating new Array instances inside a phase vocoder).
