### PR TITLE
fix ordering of duplicate events (newer should go after)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -224,7 +224,7 @@ PseudoAudioParam.prototype._insertEvent = function(eventItem) {
       }
     }
     this._eventIndex = 0;
-    events.splice(i, replace, eventItem);
+    events.splice(replace ? i : i + 1, replace, eventItem);
   }
 };
 


### PR DESCRIPTION
In the current implementation, when an event is added that is at the same time as another event (and is of a different type), it is inserted before the the other event. However this does not conform to the spec:

https://www.w3.org/TR/webaudio/#AudioParam

> - If one of these events is added at a time where there is already an event of the exact same type, then the new event will replace the old one.
> - If one of these events is added at a time where there is **already one or more events of a different type, then it will be placed in the list after them**, but before events whose times are after the event.

**This PR corrects the current behavior so that newly events are inserted after events of the same time as per the spec.**