### PR TITLE
fix insertEvent ordering when multiple events at time

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,12 +210,12 @@ PseudoAudioParam.prototype._insertEvent = function(eventItem) {
   var events = this.events;
   var replace = 0;
   var addAfter = 0;
-  var i, imax;
+  var i;
 
   if (events.length === 0 || events[events.length - 1].time < time) {
     events.push(eventItem);
   } else {
-    for (i = 0, imax = events.length; i < imax; i++) {
+    for (i = events.length - 1; i >= 0; i--) {
       if (events[i].time === time) {
         if (events[i].type === eventItem.type) {
           replace = 1;


### PR DESCRIPTION
I found one more issue with `insertEvent`.

The problem seems to occur when you already have 2 events of the same time and add a third:

```js
param.linearRampToValueAtTime(1, 7)
param.setValueAtTime(1, 7)
param.setTargetAtTime(0, 7, 0.825)

// produces:

[ 
  { type: 'linearRampToValueAtTime', time: 7, value: 1 },
  { type: 'setTargetAtTime', time: 7, value: 0, timeConstant: 0.825 },
  { type: 'setValueAtTime', time: 7, value: 1 } 
]

// expected:

[ 
  { type: 'linearRampToValueAtTime', time: 7, value: 1 },
  { type: 'setValueAtTime', time: 7, value: 1 },
  { type: 'setTargetAtTime', time: 7, value: 0, timeConstant: 0.825 }
]
```

The code is inserting the new event after the first one, but ignoring the second.

**This PR fixes the bug by changing the code to search backwards.**